### PR TITLE
add support for ppc (and add normalized vs not namespace

### DIFF
--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -19,7 +19,7 @@ type PluginInterface interface {
 	IsCreator() bool
 
 	// Extractors
-	Extract(interface{}) (PluginData, error)
+	Extract(bool) (PluginData, error)
 	Validate() bool
 	Sections() []string
 

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -55,17 +55,17 @@ func SplitDelimiterList(items []string, delim string) (map[string]string, error)
 // lookup a value, return error if not defined for either
 func LookupValue(
 	p map[string]string,
-	key1, key2 string,
+	keys ...string,
 ) (string, error) {
 
 	var value string
-	for _, key := range []string{key1, key2} {
+	for _, key := range keys {
 		value, ok := p[key]
 		if ok {
 			return value, nil
 		}
 	}
-	return value, fmt.Errorf("Cannot find keys %s or %s", key1, key2)
+	return value, fmt.Errorf("cannot find any keys in %s", keys)
 }
 
 // ArrayContainsString determines if a string is in an array

--- a/plugins/creators/artifact/artifact.go
+++ b/plugins/creators/artifact/artifact.go
@@ -29,7 +29,7 @@ func (c ArtifactCreator) Sections() []string {
 	return []string{}
 }
 
-func (c ArtifactCreator) Extract(interface{}) (plugin.PluginData, error) {
+func (c ArtifactCreator) Extract(allowFail bool) (plugin.PluginData, error) {
 	return plugin.PluginData{}, nil
 }
 func (c ArtifactCreator) IsCreator() bool   { return true }

--- a/plugins/creators/cluster/cluster.go
+++ b/plugins/creators/cluster/cluster.go
@@ -31,7 +31,7 @@ func (c ClusterCreator) Sections() []string {
 	return []string{}
 }
 
-func (c ClusterCreator) Extract(interface{}) (plugin.PluginData, error) {
+func (c ClusterCreator) Extract(allowFail bool) (plugin.PluginData, error) {
 	return plugin.PluginData{}, nil
 }
 func (c ClusterCreator) IsCreator() bool   { return true }

--- a/plugins/extractors/kernel/kernel.go
+++ b/plugins/extractors/kernel/kernel.go
@@ -52,7 +52,7 @@ func (c KernelExtractor) Validate() bool {
 
 // Extract returns kernel metadata, for a set of named sections
 // TODO eventually the user could select which sections they want
-func (c KernelExtractor) Extract(interface{}) (plugin.PluginData, error) {
+func (c KernelExtractor) Extract(allowFail bool) (plugin.PluginData, error) {
 
 	sections := map[string]plugin.PluginSection{}
 	data := plugin.PluginData{}
@@ -63,7 +63,7 @@ func (c KernelExtractor) Extract(interface{}) (plugin.PluginData, error) {
 		// Boot!
 		if name == KernelBootSection {
 			section, err := getKernelBootParams()
-			if err != nil {
+			if err != nil && !allowFail {
 				return data, err
 			}
 			sections[KernelBootSection] = section
@@ -72,7 +72,7 @@ func (c KernelExtractor) Extract(interface{}) (plugin.PluginData, error) {
 		// Kernel full config file
 		if name == KernelConfigSection {
 			section, err := getKernelBootConfig()
-			if err != nil {
+			if err != nil && !allowFail {
 				return data, err
 			}
 			sections[KernelConfigSection] = section
@@ -81,7 +81,7 @@ func (c KernelExtractor) Extract(interface{}) (plugin.PluginData, error) {
 		// Kernel full config file
 		if name == KernelModulesSection {
 			section, err := getKernelModules()
-			if err != nil {
+			if err != nil && !allowFail {
 				return data, err
 			}
 			sections[KernelModulesSection] = section

--- a/plugins/extractors/library/library.go
+++ b/plugins/extractors/library/library.go
@@ -47,7 +47,7 @@ func (e LibraryExtractor) Validate() bool {
 }
 
 // Extract returns library metadata, for a set of named sections
-func (e LibraryExtractor) Extract(interface{}) (plugin.PluginData, error) {
+func (e LibraryExtractor) Extract(allowFail bool) (plugin.PluginData, error) {
 
 	sections := map[string]plugin.PluginSection{}
 	data := plugin.PluginData{}
@@ -56,7 +56,7 @@ func (e LibraryExtractor) Extract(interface{}) (plugin.PluginData, error) {
 	for _, name := range e.sections {
 		if name == MPISection {
 			section, err := getMPIInformation()
-			if err != nil {
+			if err != nil && !allowFail {
 				return data, err
 			}
 			sections[MPISection] = section

--- a/plugins/extractors/nfd/nfd.go
+++ b/plugins/extractors/nfd/nfd.go
@@ -83,7 +83,7 @@ func (e NFDExtractor) Validate() bool {
 }
 
 // Extract returns system metadata, for a set of named sections
-func (e NFDExtractor) Extract(interface{}) (plugin.PluginData, error) {
+func (e NFDExtractor) Extract(allowFail bool) (plugin.PluginData, error) {
 
 	sections := map[string]plugin.PluginSection{}
 	data := plugin.PluginData{}
@@ -97,7 +97,7 @@ func (e NFDExtractor) Extract(interface{}) (plugin.PluginData, error) {
 
 		// This should not happen
 		if !ok {
-			fmt.Printf("%s is not a known feature source %s\n", name)
+			fmt.Printf("%s is not a known feature source\n", name)
 			continue
 		}
 		err := discovery.Discover()

--- a/plugins/extractors/system/extractors.go
+++ b/plugins/extractors/system/extractors.go
@@ -80,6 +80,8 @@ var (
 // CPU part        : 0xd40
 // CPU revision    : 1
 
+// See https://github.com/randombit/cpuinfo/blob/master/ppc/power8 for other processors
+
 // Get architecture is akin to model?
 func getCpuArchitecture(p map[string]string) (string, error) {
 	return utils.LookupValue(p, "cpu_family", "cpu_architecture")
@@ -99,7 +101,6 @@ func getCpuVendor(p map[string]string) (string, error) {
 	}
 	vendorName, ok := armVendors[vendor]
 	if !ok {
-		fmt.Printf("Warning: cannot find vendor name for %s, will return raw value\n", vendor)
 		return vendor, nil
 	}
 	return vendorName, nil
@@ -149,6 +150,10 @@ func getProcessorInformation() (plugin.PluginSection, error) {
 	processors := []map[string]string{}
 	current := map[string]string{}
 
+	// Only PPC cpuinfo has timebase
+	ppcFields := map[string]string{}
+	isPPC := strings.Contains(string(raw), "timebase")
+
 	// We need custom parsing, the sections per processor are split by newlines
 	for _, line := range lines {
 		line = strings.Trim(line, " ")
@@ -166,13 +171,20 @@ func getProcessorInformation() (plugin.PluginSection, error) {
 
 			// Replace spaces with _. Not sure if this is a good idea, but I don't like spaces
 			key = strings.ToLower(strings.ReplaceAll(key, " ", "_"))
+
+			// Is it a more global ppc field?
+			if isPPC && key != "processor" {
+				ppcFields[key] = value
+				continue
+			}
+
 			if value != "" {
 				current[key] = value
 			}
 		}
 	}
 
-	// Create common features for each processor. Note we might want to separate this into a separate
+	// Create common features for each processor, but also allow all fields as is
 	for i, p := range processors {
 		uid, ok := p["processor"]
 		if !ok {
@@ -186,12 +198,12 @@ func getProcessorInformation() (plugin.PluginSection, error) {
 		if err != nil {
 			return info, err
 		}
-		info[uid+"vendor"] = vendor
+		info[uid+"normalized.vendor"] = vendor
 
 		// bogompis should be the same after lowercase
 		bogomips, ok := p["bogomips"]
 		if ok {
-			info[uid+"botomips"] = bogomips
+			info[uid+"normalized.botomips"] = bogomips
 		}
 
 		// features or flags
@@ -199,19 +211,27 @@ func getProcessorInformation() (plugin.PluginSection, error) {
 		if err != nil {
 			return info, err
 		}
-		info[uid+"features"] = fmt.Sprintf("%s", features)
+		info[uid+"normalized.features"] = features
 
 		family, err := getCpuArchitecture(p)
 		if err != nil {
 			return info, err
 		}
-		info[uid+"family"] = fmt.Sprintf("%s", family)
+		info[uid+"normalized.family"] = family
 
 		variant, err := getCpuVariant(p)
 		if err != nil {
 			return info, err
 		}
-		info[uid+"model"] = fmt.Sprintf("%s", variant)
+		info[uid+"normalized.model"] = variant
+		if isPPC {
+			for key, value := range ppcFields {
+				info[uid+key] = value
+			}
+		}
+		for key, value := range p {
+			info[uid+"raw."+key] = value
+		}
 
 	}
 	return info, nil

--- a/plugins/extractors/system/extractors.go
+++ b/plugins/extractors/system/extractors.go
@@ -195,10 +195,9 @@ func getProcessorInformation() (plugin.PluginSection, error) {
 
 		// Parse cpu vendor - arm has a lookup
 		vendor, err := getCpuVendor(p)
-		if err != nil {
-			return info, err
+		if err == nil {
+			info[uid+"normalized.vendor"] = vendor
 		}
-		info[uid+"normalized.vendor"] = vendor
 
 		// bogompis should be the same after lowercase
 		bogomips, ok := p["bogomips"]
@@ -208,24 +207,24 @@ func getProcessorInformation() (plugin.PluginSection, error) {
 
 		// features or flags
 		features, err := getCpuFeatures(p)
-		if err != nil {
-			return info, err
+		if err == nil {
+			info[uid+"normalized.features"] = features
 		}
-		info[uid+"normalized.features"] = features
 
 		family, err := getCpuArchitecture(p)
-		if err != nil {
-			return info, err
+		if err == nil {
+			info[uid+"normalized.family"] = family
 		}
-		info[uid+"normalized.family"] = family
 
 		variant, err := getCpuVariant(p)
-		if err != nil {
-			return info, err
+		if err == nil {
+			info[uid+"normalized.model"] = variant
 		}
-		info[uid+"normalized.model"] = variant
 		if isPPC {
 			for key, value := range ppcFields {
+				if key == "model" {
+					key = "normalized.model"
+				}
 				info[uid+key] = value
 			}
 		}

--- a/plugins/extractors/system/system.go
+++ b/plugins/extractors/system/system.go
@@ -53,7 +53,7 @@ func (e SystemExtractor) Validate() bool {
 }
 
 // Extract returns system metadata, for a set of named sections
-func (e SystemExtractor) Extract(interface{}) (plugin.PluginData, error) {
+func (e SystemExtractor) Extract(allowFail bool) (plugin.PluginData, error) {
 
 	sections := map[string]plugin.PluginSection{}
 	data := plugin.PluginData{}
@@ -62,14 +62,14 @@ func (e SystemExtractor) Extract(interface{}) (plugin.PluginData, error) {
 	for _, name := range e.sections {
 		if name == ProcessorSection {
 			section, err := getProcessorInformation()
-			if err != nil {
+			if err != nil && !allowFail {
 				return data, err
 			}
 			sections[ProcessorSection] = section
 		}
 		if name == OsSection {
 			section, err := getOsInformation()
-			if err != nil {
+			if err != nil && !allowFail {
 				return data, err
 			}
 			sections[OsSection] = section
@@ -77,14 +77,14 @@ func (e SystemExtractor) Extract(interface{}) (plugin.PluginData, error) {
 
 		if name == CPUSection {
 			section, err := getCPUInformation()
-			if err != nil {
+			if err != nil && !allowFail {
 				return data, err
 			}
 			sections[CPUSection] = section
 		}
 		if name == ArchSection {
 			section, err := getArchInformation()
-			if err != nil {
+			if err != nil && !allowFail {
 				return data, err
 			}
 			sections[ArchSection] = section
@@ -92,7 +92,7 @@ func (e SystemExtractor) Extract(interface{}) (plugin.PluginData, error) {
 
 		if name == MemorySection {
 			section, err := getMemoryInformation()
-			if err != nil {
+			if err != nil && !allowFail {
 				return data, err
 			}
 			sections[MemorySection] = section

--- a/plugins/request.go
+++ b/plugins/request.go
@@ -29,7 +29,8 @@ func (r *PluginsRequest) Extract(allowFail bool) (pg.Result, error) {
 		if !p.Plugin.IsExtractor() {
 			continue
 		}
-		r, err := p.Plugin.Extract(p.Sections)
+		// We can allow failure on the level of the sections
+		r, err := p.Plugin.Extract(allowFail)
 
 		// We can allow failure
 		if err != nil && !allowFail {


### PR DESCRIPTION
Problem: we cannot support arbitrary cpuinfo entries and it is not clear which ones are normalized by the tool vs. raw. I also think extraction should not fail for an entire section if one sub-section fails, so I am extending the allowFail argument to go down one level.